### PR TITLE
optional logging fix

### DIFF
--- a/rlkit/core/logging.py
+++ b/rlkit/core/logging.py
@@ -80,7 +80,7 @@ def mkdir_p(path):
 
 
 class Logger(object):
-    def __init__(self):
+    def __init__(self, use_wandb=False):
         self._prefixes = []
         self._prefix_str = ""
 
@@ -104,6 +104,8 @@ class Logger(object):
         self._log_tabular_only = False
         self._header_printed = False
         self.table_printer = TerminalTablePrinter()
+        
+        self.use_wandb = use_wandb
 
     def reset(self):
         self.__init__()
@@ -199,10 +201,8 @@ class Logger(object):
 
     def record_tabular(self, key, val):
         self._tabular.append((self._tabular_prefix_str + str(key), str(val)))
-        try:
+        if self.use_wandb:
             wandb.log({self._tabular_prefix_str + str(key): val})
-        except:
-            pass
 
     def record_dict(self, d, prefix=None):
         if prefix is not None:

--- a/rlkit/core/logging.py
+++ b/rlkit/core/logging.py
@@ -80,7 +80,7 @@ def mkdir_p(path):
 
 
 class Logger(object):
-    def __init__(self, use_wandb=False):
+    def __init__(self, use_wandb=True):
         self._prefixes = []
         self._prefix_str = ""
 

--- a/rlkit/launchers/launcher_util.py
+++ b/rlkit/launchers/launcher_util.py
@@ -150,7 +150,6 @@ def run_experiment_here(
     experiment_uuid = actual_log_dir.split("/")[-1]
     run = None
     if variant.get("wandb", False):
-        logger.use_wandb = True
         exp_pref = variant["exp_prefix"]
         exp_id = variant["exp_id"]
         group_name = f"{exp_pref}_{exp_id}"
@@ -203,6 +202,8 @@ def run_experiment_here(
                 comments=variant.get("comments", ""),
             )
             print("Logged to ml_runlog")
+    else:
+        logger.use_wandb = False
     set_seed(seed)
     from rlkit.torch.pytorch_util import set_gpu_mode
 

--- a/rlkit/launchers/launcher_util.py
+++ b/rlkit/launchers/launcher_util.py
@@ -150,6 +150,7 @@ def run_experiment_here(
     experiment_uuid = actual_log_dir.split("/")[-1]
     run = None
     if variant.get("wandb", False):
+        logger.use_wandb = True
         exp_pref = variant["exp_prefix"]
         exp_id = variant["exp_id"]
         group_name = f"{exp_pref}_{exp_id}"


### PR DESCRIPTION
this just adds the option to use wandb or not in the logger, so this should resolve the issue of the eval tab disappearing in when logging from the drqv2 repo